### PR TITLE
Flow terms left-to-right

### DIFF
--- a/assets/javascript/main.js
+++ b/assets/javascript/main.js
@@ -12,9 +12,6 @@ var renderTemplate = function renderTemplate(templateName, data){
 };
 
 function mungePopolo(popolo) {
-  // We want the events in reverse order so the newest appears first in our table.
-  popolo.events = popolo.events.reverse();
-
   // Create some objects for faster lookups by id.
   var membershipsByAreaIdLookup = _.groupBy(popolo.memberships, 'area_id');
   var personLookup = popolo.personLookup = _.indexBy(popolo.persons, 'id');


### PR DESCRIPTION
Having them right-to-left causes too many oddities, with dates flowing
in the wrong direction, split-terms looking odd etc, so just display
everything in chronological order.

Closes #5 
